### PR TITLE
fix: changes link styles for about section

### DIFF
--- a/src/components/About.tsx
+++ b/src/components/About.tsx
@@ -9,7 +9,7 @@ export default function About() {
           I am a classical musician turned Software Engineer. Prior to joining
           the tech industry, I spent my time running my own sheet music company{" "}
           <a
-            className="underline decoration-blue-700 text-blue-600 hover:decoration-blue-900"
+            className="underline hover:text-blue-600"
             href="https://www.jdwsheetmusic.com/"
             target="_blank"
             rel="noopener noreferrer"
@@ -19,7 +19,7 @@ export default function About() {
           as well as performing and teaching in Los Angeles, CA. I enjoy working
           with React and TypeScript. I am also a prolific technical writer for{" "}
           <a
-            className="underline decoration-blue-700 text-blue-600 hover:decoration-blue-900"
+            className="underline hover:text-blue-600"
             href="https://www.freecodecamp.org/news/author/jessica-wilkins/"
             target="_blank"
             rel="noopener noreferrer"


### PR DESCRIPTION
This PR changes the link styling for the about section.
<img width="577" alt="Screen Shot 2022-08-02 at 10 36 14 PM" src="https://user-images.githubusercontent.com/67210629/182531880-eb1ee04b-3ac1-482b-a048-da943fc213b6.png">

closes #4 
